### PR TITLE
Update wget to 1.21.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,8 +35,9 @@ test:
 
 about:
   home: https://www.gnu.org/software/wget/
-  license: GPL3
+  license: GPL-3.0-or-later
   license_file: COPYING
+  license_family: GPL
   summary: utility for non-interactive download of files from the Web
   description: |
     wget is a free software package for retrieving files using HTTP, HTTPS and FTP,

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.20.1" %}
+{% set version = "1.21.3" %}
 
 package:
   name: wget
@@ -6,7 +6,7 @@ package:
 
 source:
   url: http://ftp.gnu.org/gnu/wget/wget-{{ version }}.tar.gz
-  sha256: b783b390cb571c837b392857945f5a1f00ec6b043177cc42abb8ee1b542ee1b3
+  sha256: 5726bb8bc5ca0f6dc7110f6416e4bb7019e2d2ff5bf93d1ca2ffcc6656f220e5
 
 build:
   number: 0
@@ -20,12 +20,10 @@ requirements:
   host:
     - openssl
     - libidn2
-    - libunistring
     - zlib
   run:
     - openssl
     - libidn2
-    - libunistring
     - zlib
 
 test:
@@ -45,6 +43,9 @@ about:
     the most widely-used Internet protocols.
   doc_url: https://www.gnu.org/software/wget/
   doc_source_url: https://savannah.gnu.org/projects/wget/
+  dev_url: 
+    - https://savannah.gnu.org/git/?group=wget
+    - https://git.savannah.gnu.org/git/wget.git
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
# Changes

Changes:
- Update version from `1.20.1` to `1.21.3`. Solves: https://nvd.nist.gov/vuln/detail/CVE-2019-5953
- Update sha256
- Added dev_url (link to wget git repository)
- Remove dependency on libunistring because it is not needed by wget when libidn2 version > 0.14. Current libidn2 is 2.3.

# Review Information

## Source

https://git.savannah.gnu.org/cgit/wget.git/tree/?h=v1.21.3


## License

https://git.savannah.gnu.org/cgit/wget.git/tree/README?h=v1.21.3


## Upstream Changes

https://git.savannah.gnu.org/cgit/wget.git/tree/ChangeLog?h=v1.21.3

## Issues

http://wget.addictivecode.org/BugTracker.html

## Pins and Requireds

NA

## Testing

Existing tests passed.


# Closing Comments

wget udpated to 1.21.3