### PR TITLE
Rebuild for both OpenSSL 1 and 3 (PKG-2294)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  jcmorin-ana-org: openssl

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  jcmorin-ana-org: openssl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 81542f5cefb8faacc39bbbc6c82ded80e3e4a88505ae72ea51df27525bcde04c
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 requirements:
@@ -18,11 +18,11 @@ requirements:
     - pkg-config
     - make
   host:
-    - openssl 3.0.8
+    - openssl {{ openssl }}
     - libidn2 2.3.4
     - zlib 1.2.13
   run:
-    - openssl 3.*
+    - openssl  # exact pin handled through openssl run_exports
     - libidn2
     - zlib
 


### PR DESCRIPTION
This is just a rebuild to get both OpenSSL 1 and 3 support. I won't rebuild everything, but this is a core dependency.