### PR TITLE
Wget Update 1.24.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   url: https://ftp.gnu.org/gnu/wget/wget-{{ version }}.tar.gz
   sha256: fa2dc35bab5184ecbc46a9ef83def2aaaa3f4c9f3c97d4bd19dcb07d4da637de
-  # Patching for CVE is required. When the newest version is availble,
+  # Patching for CVE-2024-38428 is required. Once a cleared version is released,
   # this patch can be removed.
   patches:
     - patches/ed0c7c7e0e8f7298352646b2fd6e06a11e242ace.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,10 @@ package:
 source:
   url: https://ftp.gnu.org/gnu/wget/wget-{{ version }}.tar.gz
   sha256: fa2dc35bab5184ecbc46a9ef83def2aaaa3f4c9f3c97d4bd19dcb07d4da637de
-
+  # Patching for CVE is required. When the newest version is availble,
+  # this patch can be removed.
+  patches:
+    - patches/ed0c7c7e0e8f7298352646b2fd6e06a11e242ace.patch
 build:
   number: 0
   skip: True  # [win]
@@ -17,6 +20,7 @@ requirements:
     - {{ compiler('c') }}
     - pkg-config
     - make
+    - patch # [unix]
   host:
     - openssl {{ openssl }}
     - libidn2 2.3.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - openssl {{ openssl }}
     - libidn2 2.3.4
     - zlib 1.2.13
-    - libunistring 0.9.1
+    - libunistring 0.9.10
   run:
     - openssl  # exact pin handled through openssl run_exports
     - libidn2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - openssl {{ openssl }}
     - libidn2 2.3.4
     - zlib 1.2.13
-    - libunistring
+    - libunistring 0.9.1
   run:
     - openssl  # exact pin handled through openssl run_exports
     - libidn2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.21.4" %}
+{% set version = "1.24.5" %}
 
 package:
   name: wget
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://ftp.gnu.org/gnu/wget/wget-{{ version }}.tar.gz
-  sha256: 81542f5cefb8faacc39bbbc6c82ded80e3e4a88505ae72ea51df27525bcde04c
+  sha256: fa2dc35bab5184ecbc46a9ef83def2aaaa3f4c9f3c97d4bd19dcb07d4da637de
 
 build:
-  number: 1
+  number: 0
   skip: True  # [win]
 
 requirements:
@@ -21,10 +21,12 @@ requirements:
     - openssl {{ openssl }}
     - libidn2 2.3.4
     - zlib 1.2.13
+    - libunistring
   run:
     - openssl  # exact pin handled through openssl run_exports
     - libidn2
     - zlib
+    - libunistring
 
 test:
   commands:

--- a/recipe/patches/ed0c7c7e0e8f7298352646b2fd6e06a11e242ace.patch
+++ b/recipe/patches/ed0c7c7e0e8f7298352646b2fd6e06a11e242ace.patch
@@ -1,0 +1,74 @@
+From ed0c7c7e0e8f7298352646b2fd6e06a11e242ace Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tim=20R=C3=BChsen?= <tim.ruehsen@gmx.de>
+Date: Sun, 2 Jun 2024 12:40:16 +0200
+Subject: Properly re-implement userinfo parsing (rfc2396)
+
+* src/url.c (url_skip_credentials): Properly re-implement userinfo parsing (rfc2396)
+
+The reason why the implementation is based on RFC 2396, an outdated standard,
+is that the whole file is based on that RFC, and mixing standard here might be
+dangerous.
+---
+ src/url.c | 40 ++++++++++++++++++++++++++++++++++------
+ 1 file changed, 34 insertions(+), 6 deletions(-)
+
+diff --git a/src/url.c b/src/url.c
+index 69e948b..07c3bc8 100644
+--- a/src/url.c
++++ b/src/url.c
+@@ -41,6 +41,7 @@ as that of the covered work.  */
+ #include "url.h"
+ #include "host.h"  /* for is_valid_ipv6_address */
+ #include "c-strcase.h"
++#include "c-ctype.h"
+
+ #ifdef HAVE_ICONV
+ # include <iconv.h>
+@@ -526,12 +527,39 @@ scheme_leading_string (enum url_scheme scheme)
+ static const char *
+ url_skip_credentials (const char *url)
+ {
+-  /* Look for '@' that comes before terminators, such as '/', '?',
+-     '#', or ';'.  */
+-  const char *p = (const char *)strpbrk (url, "@/?#;");
+-  if (!p || *p != '@')
+-    return url;
+-  return p + 1;
++  /*
++   * This whole file implements https://www.rfc-editor.org/rfc/rfc2396 .
++   * RFC 2396 is outdated since 2005 and needs a rewrite or a thorough re-visit.
++   *
++   * The RFC says
++   * server        = [ [ userinfo "@" ] hostport ]
++   * userinfo      = *( unreserved | escaped | ";" | ":" | "&" | "=" | "+" | "$" | "," )
++   * unreserved    = alphanum | mark
++   * mark          = "-" | "_" | "." | "!" | "~" | "*" | "'" | "(" | ")"
++   */
++  static const char *allowed = "-_.!~*'();:&=+$,";
++
++  for (const char *p = url; *p; p++)
++    {
++      if (c_isalnum(*p))
++        continue;
++
++      if (strchr(allowed, *p))
++        continue;
++
++      if (*p == '%' && c_isxdigit(p[1]) && c_isxdigit(p[2]))
++        {
++          p += 2;
++          continue;
++        }
++
++      if (*p == '@')
++        return p + 1;
++
++      break;
++    }
++
++  return url;
+ }
+
+ /* Parse credentials contained in [BEG, END).  The region is expected
+--
+cgit v1.1


### PR DESCRIPTION
## ☆ Wget 1.24.5 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-5503)
[Upstream](https://www.gnu.org/software/wget/)

Changes
 - Updated version number and sha256
 - Added new dependency `libuinistring 0.91`